### PR TITLE
구 주소(wooin-media) → 신규 주소(wooinmedia) 리다이렉트 설정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "destination": "https://wooinmedia.vercel.app/:path*",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
안녕하세요! Blinker 운영 프론트가 wooinmedia.vercel.app 으로 이관되어, 기존 주소로 들어오는 사용자를 새 주소로 보내기 위한 리다이렉트 설정입니다.

- `vercel.json` 한 파일 추가 — 모든 경로/쿼리를 보존하여 https://wooinmedia.vercel.app 으로 307 리다이렉트
- 이 PR을 머지해주시면 기존 Vercel 프로젝트(wooin-media.vercel.app)가 자동으로 리다이렉트 배포됩니다
- 코드 변경 없음, 롤백은 이 커밋 revert로 즉시 가능합니다

머지만 부탁드립니다. 감사합니다! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)